### PR TITLE
Fix chunk loading deadlock

### DIFF
--- a/src/main/java/com/esm/nightmare/NightmareMain.java
+++ b/src/main/java/com/esm/nightmare/NightmareMain.java
@@ -150,7 +150,8 @@ public class NightmareMain {
 						// If mob was not summoned after it was spawned and is not loading from save,
 						// then...
 						if (e.getSpawnType() != MobSpawnType.MOB_SUMMONED
-								&& e.getSpawnType() != MobSpawnType.CHUNK_GENERATION) {
+								&& e.getSpawnType() != MobSpawnType.CHUNK_GENERATION &&
+								e.getSpawnType() != MobSpawnType.STRUCTURE) {
 							int TotalDupes = new RNG().GetInt(MinDupes, MaxDupes);
 							if (ShouldDuplicate()) {
 								new DuplicateMob(M, TotalDupes);


### PR DESCRIPTION
Fixes common deadlock by ensuring that the MobSpawnType in NightmareMain.java:#152 is not a structure.